### PR TITLE
Fix optionDef io-ts type

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -71,8 +71,7 @@ const thing: OneEvent = {
         purge: None
     },
     data: Some({
-        foo: 'bar',
-        blah: true,
+        foo: 'bar'
     })
 };
 
@@ -84,5 +83,5 @@ const blahOpt = optionDef(blah);
 
 type BlahOpt = T.TypeOf<typeof blahOpt>;
 
-const bobs: BlahOpt = Some({ baz: 'asdas' });
+const bobs: BlahOpt = Option.of({ baz: 'asdas', buz: 'as' });
 

--- a/types.ts
+++ b/types.ts
@@ -1,24 +1,43 @@
-import * as T from 'io-ts';
-import { Option, None, Some } from 'funfix';
+import * as T from "io-ts";
+import { Option, None, Some } from "funfix";
 
 const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
-export const uuidDef = T.refinement(T.string, str => uuidRegex.test(str), 'UUID');
+export const uuidDef = T.refinement(
+  T.string,
+  str => uuidRegex.test(str),
+  "UUID"
+);
 export type Uuid = T.TypeOf<typeof uuidDef>;
 
 const isoDateRegex = /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)$/;
-export const isoDateDef = T.refinement(T.string, str => isoDateRegex.test(str), 'ISO-8601');
+export const isoDateDef = T.refinement(
+  T.string,
+  str => isoDateRegex.test(str),
+  "ISO-8601"
+);
 export type IsoDate = T.TypeOf<typeof isoDateDef>;
 
-export const optionDef = <A extends T.Mixed>(data: A): T.Type<Option<A>> =>
-    new T.Type<Option<A>, A | null>(
-        `Option<${data.name}>`,
-        (u): u is Option<A> => u instanceof Option,
-        (u, c) => {
-            const ret = Option.of(u);
+export type OptionCodec<C extends T.Mixed> = T.Type<
+  Option<T.TypeOf<C>>,
+  T.OutputOf<C> | T.OutputOf<T.NullType>,
+  unknown
+>;
 
-            return ret
-                .map(s => data.validate(s, c).chain(s => T.success(Option.of(s))))
-                .getOrElse(T.success(None));
-        },
-        (a: Option<A>): A | null => a.getOrElse(null)
-    );
+export function optionDef<C extends T.Mixed>(
+  codec: C,
+  name: string = `Option<${codec.name}>`
+): OptionCodec<C> {
+  return new T.Type(
+    name,
+    (u): u is Option<T.TypeOf<C>> => u instanceof Option,
+    (u, c) =>
+      Option.of(u)
+        .map(value => {
+          return codec
+            .validate(value, c)
+            .chain(value => T.success(Option.of(value)));
+        })
+        .getOrElse(T.success(None)),
+    a => a.getOrElse(null)
+  );
+}


### PR DESCRIPTION
Take into consideration that interfaces are not sealed:

```

interface A {
  a: string;
}

// This compiles
const obj: A = {a: 'a', b: 'b'};

// This does not compile
const obj: A = { b: 'b' }
```

To check for extra properties you can use sealed:
https://github.com/repositive/mnemosyne/blob/8eb273f4856846544b6d984688caebd4407c0875/src/util/io-ts-extra.ts#L17